### PR TITLE
feat: change data directory for emoji example to ".config/frece"

### DIFF
--- a/examples/dir_rofi.sh
+++ b/examples/dir_rofi.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DB_FILE="$HOME/.frece/db/dir.db"
+DATA_DIR="$HOME/.config/frece"
+DB_FILE="$DATA_DIR/dir.db"
 
 item=$(frece print "$DB_FILE" | rofi "$@" -dmenu)
 [[ -z $item ]] && exit 1

--- a/examples/dir_rofi.sh
+++ b/examples/dir_rofi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATA_DIR="$HOME/.config/frece"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/frece"
 DB_FILE="$DATA_DIR/dir.db"
 
 item=$(frece print "$DB_FILE" | rofi "$@" -dmenu)

--- a/examples/dir_update.sh
+++ b/examples/dir_update.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-DB_FILE="$HOME/.frece/db/dir.db"
+DATA_DIR="$HOME/.config/frece"
+DB_FILE="$DATA_DIR/dir.db"
 ENTRIES_FILE="/tmp/frece_dir_entries.txt"
 
 find "$@" -path '*/\.*' -prune -o -not -name '.*' -type d -print | \
     sort > "$ENTRIES_FILE"
+
+[ ! -d "$DATA_DIR" ] && mkdir -p "$DATA_DIR"
 
 if [ ! -f "$DB_FILE" ]; then
     frece init "$DB_FILE" "$ENTRIES_FILE"

--- a/examples/dir_update.sh
+++ b/examples/dir_update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATA_DIR="$HOME/.config/frece"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/frece"
 DB_FILE="$DATA_DIR/dir.db"
 ENTRIES_FILE="/tmp/frece_dir_entries.txt"
 

--- a/examples/emoji_rofi.sh
+++ b/examples/emoji_rofi.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DB_FILE="$HOME/.frece/db/emoji.db"
+DATA_DIR="$HOME/.config/frece"
+DB_FILE="$DATA_DIR/emoji.db"
 
 item=$(frece print "$DB_FILE" | rofi "$@" -dmenu)
 [[ -z $item ]] && exit 1

--- a/examples/emoji_rofi.sh
+++ b/examples/emoji_rofi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATA_DIR="$HOME/.config/frece"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/frece"
 DB_FILE="$DATA_DIR/emoji.db"
 
 item=$(frece print "$DB_FILE" | rofi "$@" -dmenu)

--- a/examples/emoji_update.sh
+++ b/examples/emoji_update.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-DB_FILE="$HOME/.frece/db/emoji.db"
+DATA_DIR="$HOME/.config/frece"
+DB_FILE="$DATA_DIR/emoji.db"
 ENTRIES_FILE="/tmp/frece_emoji_entries.txt"
-CUSTOM_ENTRIES_FILE="$HOME/.frece/src/emoji_custom.txt"
+CUSTOM_ENTRIES_FILE="$DATA_DIR/emoji_custom.txt"
 URL="http://www.unicode.org/Public/emoji/11.0/emoji-test.txt"
 
 curl -s "$URL" | \
     sed 's/^[^#]*; fully-qualified *# \([^ ]*\)/\1 \t/gp;d' > "$ENTRIES_FILE"
+
+[ ! -d "$DATA_DIR" ] && mkdir -p "$DATA_DIR"
 
 [ -f "$CUSTOM_ENTRIES_FILE" ] && cat "$CUSTOM_ENTRIES_FILE" >> "$ENTRIES_FILE"
 

--- a/examples/emoji_update.sh
+++ b/examples/emoji_update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATA_DIR="$HOME/.config/frece"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/frece"
 DB_FILE="$DATA_DIR/emoji.db"
 ENTRIES_FILE="/tmp/frece_emoji_entries.txt"
 CUSTOM_ENTRIES_FILE="$DATA_DIR/emoji_custom.txt"

--- a/examples/file_rofi.sh
+++ b/examples/file_rofi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATA_DIR="$HOME/.config/frece"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/frece"
 DB_FILE="$DATA_DIR/file.db"
 
 item=$(frece print "$DB_FILE" | rofi "$@" -dmenu)

--- a/examples/file_rofi.sh
+++ b/examples/file_rofi.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-DB_FILE="$HOME/.frece/db/file.db"
+DATA_DIR="$HOME/.config/frece"
+DB_FILE="$DATA_DIR/file.db"
 
 item=$(frece print "$DB_FILE" | rofi "$@" -dmenu)
 [[ -z $item ]] && exit 1

--- a/examples/file_update.sh
+++ b/examples/file_update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATA_DIR="$HOME/.config/frece"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/frece"
 DB_FILE="$DATA_DIR/file.db"
 ENTRIES_FILE="/tmp/frece_file_entries.txt"
 

--- a/examples/file_update.sh
+++ b/examples/file_update.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-DB_FILE="$HOME/.frece/db/file.db"
+DATA_DIR="$HOME/.config/frece"
+DB_FILE="$DATA_DIR/file.db"
 ENTRIES_FILE="/tmp/frece_file_entries.txt"
 
 find "$@" -path '*/\.*' -prune -o -not -name '.*' -type f -print | \
     sort > "$ENTRIES_FILE"
+
+[ ! -d "$DATA_DIR" ] && mkdir -p "$DATA_DIR"
 
 if [ ! -f "$DB_FILE" ]; then
     frece init "$DB_FILE" "$ENTRIES_FILE"


### PR DESCRIPTION
Hi, I noticed that the execution of the script `emoji_update.sh` initially fails because the directory where the database is located is not created by the script.

I have added a simple check to create the directory if it does not exist.

I also adjusted the path where the database and the custom_emojis are located to keep the home directory clear.